### PR TITLE
fix: use rusty error handling

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -12,14 +12,6 @@ struct RunTime {
     had_error: bool,
 }
 
-pub(crate) fn error(line: usize, message: &str) {
-    report(line, "", message);
-}
-
-fn report(line: usize, location: &str, message: &str) {
-    eprintln!("[line {}] Error{}: {}", line, location, message);
-}
-
 impl RunTime {
     fn new() -> RunTime {
         RunTime { had_error: false }
@@ -27,10 +19,27 @@ impl RunTime {
 
     fn run(&mut self, code: &String) {
         let mut scanner = Scanner::new(code);
-        let tokens = scanner.scan_tokens();
+
+        let (tokens, errs) = scanner.scan_tokens();
+        for err in errs {
+            let (line, msg) = err;
+            self.error(line, &msg)
+        }
         for token in tokens {
             println!("{}", token);
         }
+        // parse the tokens
+        // type infer the parse
+        // do environment
+    }
+
+    fn error(&mut self, line: usize, message: &str) {
+        self.report(line, "", message);
+        self.had_error = true;
+    }
+
+    fn report(&self, line: usize, location: &str, message: &str) {
+        eprintln!("[line {}] Error{}: {}", line, location, message);
     }
 
     pub fn run_file(&mut self, file_path: &String) {


### PR DESCRIPTION
* have scanner return a tuple of tokens and errors
* have methods within the scanner return `Result` instead of calling error inline
* fix while loop lifetime issue by using options to know when to stop (prevents borrowing twice)
* recover from error state in runtime by just printing all errors and marking the runtime as having errored