### PR TITLE
feat: start of AST for expressions with pretty printing

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,0 +1,76 @@
+use crate::token::Token;
+use crate::PrettyPrinting;
+
+pub enum Expr<'a> {
+    Binary {
+        left: Box<Expr<'a>>,
+        right: Box<Expr<'a>>,
+        op: Token<'a>,
+    },
+    Unary {
+        right: Box<Expr<'a>>,
+        op: Token<'a>,
+    },
+    Grouping {
+        expression: Box<Expr<'a>>,
+    },
+    Literal {
+        value: Token<'a>,
+    },
+}
+
+impl PrettyPrinting for Expr<'_> {
+    fn print(&self) -> String {
+        match self {
+            Expr::Binary { left, right, op } => {
+                format!("({} {} {})", op.print(), left.print(), right.print())
+            }
+            Expr::Unary { right, op } => format!("({} {})", op.print(), right.print()),
+            Expr::Grouping { expression } => format!("(group {})", expression.print()),
+            Expr::Literal { value } => value.print(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // Note this useful idiom: importing names from outer (for mod tests) scope.
+    use super::*;
+    use crate::token::{Token, TokenType};
+
+    #[test]
+    fn test_pretty_print() {
+        let expression = Expr::Binary {
+            left: Box::new(Expr::Unary {
+                op: Token {
+                    t: TokenType::Minus,
+                    lexeme: "-",
+                    line: 1,
+                },
+                right: Box::new(Expr::Literal {
+                    value: Token {
+                        t: TokenType::Number(123.0),
+                        lexeme: "45.67",
+                        line: 1,
+                    },
+                }),
+            }),
+            op: Token {
+                t: TokenType::Star,
+                lexeme: "*",
+                line: 1,
+            },
+            right: Box::new(Expr::Grouping {
+                expression: Box::new(Expr::Literal {
+                    value: Token {
+                        t: TokenType::Number(45.67),
+                        lexeme: "45.67",
+                        line: 1,
+                    },
+                }),
+            }),
+        };
+
+        assert_eq!(expression.print(), "(* (- 123) (group 45.67))");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,8 +2,13 @@ use std::env;
 use std::fs;
 use std::io::{self, Write};
 
+mod ast;
 mod scanner;
 mod token;
+
+pub trait PrettyPrinting {
+    fn print(&self) -> String;
+}
 
 use crate::scanner::Scanner;
 

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,5 +1,7 @@
 use std::fmt;
 
+use crate::PrettyPrinting;
+
 #[derive(Copy, Clone, Debug)]
 pub enum TokenType<'literal> {
     // Single-character tokens
@@ -72,5 +74,16 @@ pub struct Token<'code> {
 impl fmt::Display for Token<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "[{}] {} {}", self.line, self.t, self.lexeme)
+    }
+}
+
+impl PrettyPrinting for Token<'_> {
+    fn print(&self) -> String {
+        match self.t {
+            TokenType::Nil => "nil".to_string(),
+            TokenType::Number(v) => format!("{}", v),
+            TokenType::String(v) => v.to_string(),
+            _ => self.lexeme.to_string(),
+        }
     }
 }


### PR DESCRIPTION
[Chapter 5 of Crafting Interpreters](https://craftinginterpreters.com/representing-code.html#implementing-syntax-trees) uses the visitor pattern with java to dispatch methods for given functionality on the AST.  This seems a bit clunky in rust, which has pattern matching, so I've instead used a trait for `PrettyPrinting` and match on the enum's to implement it.  We'll see if this bites me later...

* Add an enum with different expression nodes in the AST
* Add pretty printing on the AST
* Test the pretty printing