### PR TITLE
Add statements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,73 @@
 version = 3
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "colored"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
+dependencies = [
+ "atty",
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "libc"
+version = "0.2.134"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
+
+[[package]]
 name = "lox-rs"
 version = "0.1.0"
+dependencies = [
+ "colored",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+colored = "2.0.0"

--- a/lox-programs/scope.lox
+++ b/lox-programs/scope.lox
@@ -1,0 +1,19 @@
+var a = "global a";
+var b = "global b";
+var c = "global c";
+{
+  var a = "outer a";
+  var b = "outer b";
+  {
+    var a = "inner a";
+    print a;
+    print b;
+    print c;
+  }
+  print a;
+  print b;
+  print c;
+}
+print a;
+print b;
+print c;

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -32,6 +32,23 @@ impl PrettyPrinting for Expr<'_> {
     }
 }
 
+pub enum Stmt<'a> {
+    Expression { expression: Expr<'a> },
+    Print { expression: Expr<'a> },
+}
+
+// TODO: JUST USE FMT::DISPLAY
+impl PrettyPrinting for Stmt<'_> {
+    fn print(&self) -> String {
+        match self {
+            Stmt::Print { expression } => {
+                format!("(print {} )", expression.print())
+            }
+            Stmt::Expression { expression } => format!("(; {})", expression.print()),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     // Note this useful idiom: importing names from outer (for mod tests) scope.

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,28 +1,29 @@
 use crate::token::Token;
 use crate::PrettyPrinting;
 
-pub enum Expr<'a> {
+#[derive(Clone, Debug)]
+pub enum Expr {
     Binary {
-        left: Box<Expr<'a>>,
-        right: Box<Expr<'a>>,
-        op: Token<'a>,
+        left: Box<Expr>,
+        right: Box<Expr>,
+        op: Token,
     },
     Grouping {
-        expression: Box<Expr<'a>>,
+        expression: Box<Expr>,
     },
     Literal {
-        value: Token<'a>,
+        value: Token,
     },
     Unary {
-        right: Box<Expr<'a>>,
-        op: Token<'a>,
+        right: Box<Expr>,
+        op: Token,
     },
     Variable {
-        name: Token<'a>,
+        name: Token,
     },
 }
 
-impl PrettyPrinting for Expr<'_> {
+impl PrettyPrinting for Expr {
     fn print(&self) -> String {
         match self {
             Expr::Binary { left, right, op } => {
@@ -36,21 +37,21 @@ impl PrettyPrinting for Expr<'_> {
     }
 }
 
-pub enum Stmt<'a> {
+pub enum Stmt {
     Expression {
-        expression: Expr<'a>,
+        expression: Expr,
     },
     Print {
-        expression: Expr<'a>,
+        expression: Expr,
     },
     Var {
-        name: Token<'a>,
-        initializer: Option<Expr<'a>>,
+        name: Token,
+        initializer: Option<Expr>,
     },
 }
 
 // TODO: JUST USE FMT::DISPLAY
-impl PrettyPrinting for Stmt<'_> {
+impl PrettyPrinting for Stmt {
     fn print(&self) -> String {
         match self {
             Stmt::Print { expression } => {

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -58,7 +58,6 @@ pub enum Stmt {
     },
 }
 
-// TODO: JUST USE FMT::DISPLAY
 impl PrettyPrinting for Stmt {
     fn print(&self) -> String {
         match self {
@@ -67,7 +66,7 @@ impl PrettyPrinting for Stmt {
                 for statement in statements {
                     s = s + &format!(" {}", statement.print())
                 }
-                s
+                s + ")"
             }
             Stmt::Expression { expression } => format!("(; {})", expression.print()),
             Stmt::Print { expression } => {

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -3,10 +3,14 @@ use crate::PrettyPrinting;
 
 #[derive(Clone, Debug)]
 pub enum Expr {
+    Assign {
+        name: Token,
+        value: Box<Expr>,
+    },
     Binary {
         left: Box<Expr>,
-        right: Box<Expr>,
         op: Token,
+        right: Box<Expr>,
     },
     Grouping {
         expression: Box<Expr>,
@@ -15,8 +19,8 @@ pub enum Expr {
         value: Token,
     },
     Unary {
-        right: Box<Expr>,
         op: Token,
+        right: Box<Expr>,
     },
     Variable {
         name: Token,
@@ -26,6 +30,7 @@ pub enum Expr {
 impl PrettyPrinting for Expr {
     fn print(&self) -> String {
         match self {
+            Expr::Assign { name, value } => format!("(= {} {})", name.print(), value.print()),
             Expr::Binary { left, right, op } => {
                 format!("({} {} {})", op.print(), left.print(), right.print())
             }
@@ -38,6 +43,9 @@ impl PrettyPrinting for Expr {
 }
 
 pub enum Stmt {
+    Block {
+        statements: Vec<Box<Stmt>>,
+    },
     Expression {
         expression: Expr,
     },
@@ -54,10 +62,17 @@ pub enum Stmt {
 impl PrettyPrinting for Stmt {
     fn print(&self) -> String {
         match self {
+            Stmt::Block { statements } => {
+                let mut s = "(block".to_string();
+                for statement in statements {
+                    s = s + &format!(" {}", statement.print())
+                }
+                s
+            }
+            Stmt::Expression { expression } => format!("(; {})", expression.print()),
             Stmt::Print { expression } => {
                 format!("(print {} )", expression.print())
             }
-            Stmt::Expression { expression } => format!("(; {})", expression.print()),
             Stmt::Var { name, initializer } => match initializer {
                 Some(v) => format!("(var {} {})", name.print(), v.print()),
                 None => format!("(var {})", name.print()),

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -44,7 +44,7 @@ impl PrettyPrinting for Expr {
 
 pub enum Stmt {
     Block {
-        statements: Vec<Box<Stmt>>,
+        statements: Vec<Stmt>,
     },
     Expression {
         expression: Expr,
@@ -71,7 +71,7 @@ impl PrettyPrinting for Stmt {
             }
             Stmt::Expression { expression } => format!("(; {})", expression.print()),
             Stmt::Print { expression } => {
-                format!("(print {} )", expression.print())
+                format!("(print {})", expression.print())
             }
             Stmt::Var { name, initializer } => match initializer {
                 Some(v) => format!("(var {} {})", name.print(), v.print()),

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -7,15 +7,18 @@ pub enum Expr<'a> {
         right: Box<Expr<'a>>,
         op: Token<'a>,
     },
-    Unary {
-        right: Box<Expr<'a>>,
-        op: Token<'a>,
-    },
     Grouping {
         expression: Box<Expr<'a>>,
     },
     Literal {
         value: Token<'a>,
+    },
+    Unary {
+        right: Box<Expr<'a>>,
+        op: Token<'a>,
+    },
+    Variable {
+        name: Token<'a>,
     },
 }
 
@@ -28,13 +31,22 @@ impl PrettyPrinting for Expr<'_> {
             Expr::Unary { right, op } => format!("({} {})", op.print(), right.print()),
             Expr::Grouping { expression } => format!("(group {})", expression.print()),
             Expr::Literal { value } => value.print(),
+            Expr::Variable { name } => name.print(),
         }
     }
 }
 
 pub enum Stmt<'a> {
-    Expression { expression: Expr<'a> },
-    Print { expression: Expr<'a> },
+    Expression {
+        expression: Expr<'a>,
+    },
+    Print {
+        expression: Expr<'a>,
+    },
+    Var {
+        name: Token<'a>,
+        initializer: Option<Expr<'a>>,
+    },
 }
 
 // TODO: JUST USE FMT::DISPLAY
@@ -45,6 +57,10 @@ impl PrettyPrinting for Stmt<'_> {
                 format!("(print {} )", expression.print())
             }
             Stmt::Expression { expression } => format!("(; {})", expression.print()),
+            Stmt::Var { name, initializer } => match initializer {
+                Some(v) => format!("(var {} {})", name.print(), v.print()),
+                None => format!("(var {})", name.print()),
+            },
         }
     }
 }

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
-use crate::token::Token;
 use crate::interpreter::LoxValue;
+use crate::token::Token;
 
 #[derive(Debug)]
 pub struct Environment {
@@ -19,9 +19,8 @@ impl Environment {
             None => Environment {
                 values: HashMap::new(),
                 parent: None,
-            }
+            },
         }
-
     }
 
     pub fn define(&mut self, name: &Token, value: LoxValue) {
@@ -31,12 +30,10 @@ impl Environment {
     pub fn get(&self, name: &Token) -> Option<LoxValue> {
         match self.values.get(&name.lexeme.to_string()) {
             Some(v) => Some(v.clone()),
-            None => {
-                match &self.parent {
-                    Some(e) => e.get(name),
-                    None => None
-                }
-            }
+            None => match &self.parent {
+                Some(e) => e.get(name),
+                None => None,
+            },
         }
     }
 }

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -1,0 +1,42 @@
+use std::collections::HashMap;
+
+use crate::token::Token;
+use crate::interpreter::LoxValue;
+
+#[derive(Debug)]
+pub struct Environment {
+    values: HashMap<String, LoxValue>,
+    parent: Option<Box<Environment>>,
+}
+
+impl Environment {
+    pub fn new(parent: Option<Environment>) -> Self {
+        match parent {
+            Some(e) => Environment {
+                values: HashMap::new(),
+                parent: Some(Box::new(e)),
+            },
+            None => Environment {
+                values: HashMap::new(),
+                parent: None,
+            }
+        }
+
+    }
+
+    pub fn define(&mut self, name: &Token, value: LoxValue) {
+        self.values.insert(name.lexeme.to_string(), value);
+    }
+
+    pub fn get(&self, name: &Token) -> Option<LoxValue> {
+        match self.values.get(&name.lexeme.to_string()) {
+            Some(v) => Some(v.clone()),
+            None => {
+                match &self.parent {
+                    Some(e) => e.get(name),
+                    None => None
+                }
+            }
+        }
+    }
+}

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -13,15 +13,9 @@ pub struct Environment {
 
 impl Environment {
     pub fn new(enclosing: Option<Rc<RefCell<Environment>>>) -> Self {
-        match enclosing {
-            Some(e) => Environment {
-                values: HashMap::new(),
-                enclosing: Some(Rc::clone(&e)),
-            },
-            None => Environment {
-                values: HashMap::new(),
-                enclosing: None,
-            },
+        Environment {
+            values: HashMap::new(),
+            enclosing,
         }
     }
 
@@ -39,15 +33,14 @@ impl Environment {
         }
     }
 
-    pub fn assign(&mut self, name: &Token, value: LoxValue) -> Option<LoxValue> {
+    pub fn assign(&mut self, name: &Token, value: LoxValue) -> Option<()> {
         if self.values.contains_key(&name.lexeme) {
-            return match self.values.insert(name.lexeme.clone(), value.clone()) {
-                Some(v) => Some(v),
-                None => match &mut self.enclosing {
-                    Some(e) => e.borrow_mut().assign(name, value),
-                    None => None,
-                },
-            };
+            self.values.insert(name.lexeme.clone(), value);
+            return Some(());
+        }
+
+        if let Some(e) = &self.enclosing {
+            return e.borrow_mut().assign(name, value);
         }
 
         None

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -112,8 +112,6 @@ impl Interpreter {
                 for statement in statements {
                     self.execute(statement, Rc::clone(&block_environment))?;
                 }
-                // should always be true given we construct the environment with an
-                // enclosing environment above
             }
             Stmt::Expression { expression } => {
                 self.evaluate(expression, environment)?;

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -103,7 +103,7 @@ impl Interpreter {
         &self,
         stmt: Stmt,
         environment: Rc<RefCell<Environment>>,
-    ) -> Result<LoxValue, InterpreterError> {
+    ) -> Result<(), InterpreterError> {
         match stmt {
             Stmt::Block { statements } => {
                 let block_environment = Rc::new(RefCell::new(Environment::new(Some(environment))));
@@ -112,13 +112,13 @@ impl Interpreter {
                 }
                 // should always be true given we construct the environment with an
                 // enclosing environment above
-                Ok(LoxValue::Nil)
             }
-            Stmt::Expression { expression } => self.evaluate(expression, environment),
+            Stmt::Expression { expression } => {
+                self.evaluate(expression, environment)?;
+            }
             Stmt::Print { expression } => {
                 let value = self.evaluate(expression, Rc::clone(&environment))?;
                 println!("{}", value);
-                Ok(value)
             }
             Stmt::Var { name, initializer } => {
                 let mut value = LoxValue::Nil;
@@ -127,9 +127,10 @@ impl Interpreter {
                 }
 
                 environment.borrow_mut().define(&name, value);
-                Ok(LoxValue::Nil)
             }
-        }
+        };
+
+        Ok(())
     }
 
     fn evaluate(

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -26,15 +26,15 @@ impl PartialEq for LoxValue {
     }
 }
 
-impl TryFrom<&Token<'_>> for LoxValue {
+impl TryFrom<&Token> for LoxValue {
     type Error = InterpreterError;
 
-    fn try_from(value: &Token<'_>) -> Result<Self, Self::Error> {
-        match value.t {
+    fn try_from(value: &Token) -> Result<Self, Self::Error> {
+        match &value.t {
             TokenType::Nil => Ok(Self::Nil),
             TokenType::True => Ok(Self::Boolean(true)),
             TokenType::False => Ok(Self::Boolean(false)),
-            TokenType::Number(v) => Ok(Self::Number(v)),
+            TokenType::Number(v) => Ok(Self::Number(*v)),
             TokenType::String(v) => Ok(Self::String(v.to_string())),
             _ => Err(InterpreterError::from_token(value, "Unexpected value")),
         }
@@ -59,7 +59,7 @@ pub struct InterpreterError {
 }
 
 impl InterpreterError {
-    pub fn from_token(token: &Token<'_>, message: impl AsRef<str>) -> Self {
+    pub fn from_token(token: &Token, message: impl AsRef<str>) -> Self {
         Self {
             line: token.line,
             location: token.lexeme.to_string(),
@@ -122,7 +122,7 @@ impl Interpreter {
             Expr::Literal { value } => (&value).try_into(),
             Expr::Unary { op, right } => {
                 let right_val = self.evaluate(*right)?;
-                match (op.t, right_val) {
+                match (&op.t, right_val) {
                     (TokenType::Minus, LoxValue::Number(n)) => Ok(LoxValue::Number(-1.0 * n)),
                     (TokenType::Minus, _) => Err(InterpreterError::from_token(
                         &op,
@@ -141,7 +141,7 @@ impl Interpreter {
                 let left_val = self.evaluate(*left)?;
                 let right_val = self.evaluate(*right)?;
 
-                match (op.t, left_val, right_val) {
+                match (&op.t, left_val, right_val) {
                     // subtraction
                     (TokenType::Minus, LoxValue::Number(a), LoxValue::Number(b)) => {
                         Ok(LoxValue::Number(a - b))

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -80,20 +80,20 @@ impl Reportable for InterpreterError {
 }
 
 #[derive(Debug)]
-pub struct Interpreter {}
+pub struct Interpreter {
+    environment: Rc<RefCell<Environment>>,
+}
 
 impl Interpreter {
     pub fn new() -> Self {
-        Self {}
+        Self {
+            environment: Rc::new(RefCell::new(Environment::new(None))),
+        }
     }
 
-    pub fn interpret(
-        &self,
-        environment: Rc<RefCell<Environment>>,
-        stmts: Vec<Stmt>,
-    ) -> Result<(), InterpreterError> {
+    pub fn interpret(&self, stmts: Vec<Stmt>) -> Result<(), InterpreterError> {
         for stmt in stmts {
-            self.execute(stmt, Rc::clone(&environment))?;
+            self.execute(stmt, Rc::clone(&self.environment))?;
         }
 
         Ok(())
@@ -106,7 +106,9 @@ impl Interpreter {
     ) -> Result<(), InterpreterError> {
         match stmt {
             Stmt::Block { statements } => {
-                let block_environment = Rc::new(RefCell::new(Environment::new(Some(environment))));
+                let block_environment = Rc::new(RefCell::new(Environment::new(Some(Rc::clone(
+                    &environment,
+                )))));
                 for statement in statements {
                     self.execute(statement, Rc::clone(&block_environment))?;
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,7 +62,7 @@ impl RunTime {
 
         // short circuit at this point if we've had errors
         if self.had_error {
-            println!("\nOH NO! we had an error!");
+            eprintln!("\nOH NO! we had an error!");
             return;
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,9 @@
-use std::cell::RefCell;
 use std::env;
 use std::fs;
 use std::io::{self, Write};
-use std::rc::Rc;
 
 use colored::Colorize;
 
-use crate::environment::Environment;
 use crate::interpreter::Interpreter;
 use crate::parser::Parser;
 use crate::scanner::Scanner;
@@ -30,7 +27,7 @@ pub trait Reportable {
 struct RunTime {
     had_error: bool,
     had_runtime_error: bool,
-    environment: Rc<RefCell<Environment>>,
+    interpreter: Interpreter,
 }
 
 impl RunTime {
@@ -38,7 +35,7 @@ impl RunTime {
         RunTime {
             had_error: false,
             had_runtime_error: false,
-            environment: Rc::new(RefCell::new(Environment::new(None))),
+            interpreter: Interpreter::new(),
         }
     }
 
@@ -74,14 +71,9 @@ impl RunTime {
         }
 
         println!("{}", "\nResult:".bold().green());
-        let interpreter = Interpreter::new();
-        if let Err(err) = interpreter.interpret(Rc::clone(&self.environment), ast) {
+        if let Err(err) = self.interpreter.interpret(ast) {
             self.runtime_error(err);
         }
-
-        // type infer the parse
-        // do environment
-        // ...
     }
 
     fn error(&mut self, err: impl Reportable) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,14 +22,14 @@ use crate::parser::Parser;
 use crate::scanner::Scanner;
 
 #[derive(Debug)]
-struct RunTime {
+struct RunTime<'e> {
     had_error: bool,
     had_runtime_error: bool,
-    interpreter: Interpreter,
+    interpreter: Interpreter<'e>,
 }
 
-impl RunTime {
-    fn new() -> RunTime {
+impl<'e> RunTime<'e> {
+    fn new() -> RunTime<'e> {
         RunTime {
             had_error: false,
             had_runtime_error: false,

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,8 @@ use std::fs;
 use std::io::{self, Write};
 use std::rc::Rc;
 
+use colored::Colorize;
+
 use crate::environment::Environment;
 use crate::interpreter::Interpreter;
 use crate::parser::Parser;
@@ -48,7 +50,7 @@ impl RunTime {
             self.error(err)
         }
 
-        println!("\nScanned tokens:");
+        println!("{}", "\nScanned tokens:".bold().cyan());
         for token in tokens {
             println!("{}", token)
         }
@@ -62,16 +64,16 @@ impl RunTime {
 
         // short circuit at this point if we've had errors
         if self.had_error {
-            eprintln!("\nOH NO! we had an error!");
+            eprintln!("{}", "\nOH NO! we had an error!".bold().red());
             return;
         }
 
-        println!("\nParsed AST:");
+        println!("{}", "\nParsed AST:".bold().yellow());
         for stmt in &ast {
             println!("{}", stmt.print());
         }
 
-        println!("\nResult:");
+        println!("{}", "\nResult:".bold().green());
         let interpreter = Interpreter::new();
         if let Err(err) = interpreter.interpret(Rc::clone(&self.environment), ast) {
             self.runtime_error(err);

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,7 +49,7 @@ impl RunTime {
 
         // parsing phase
         let mut parser = Parser::new(tokens);
-        let (result, parse_errs) = parser.parse();
+        let (ast, parse_errs) = parser.parse();
         for err in parse_errs {
             self.error(err)
         }
@@ -60,14 +60,11 @@ impl RunTime {
             return;
         }
 
-        if let Some(ast) = result {
-            println!("{}", ast.print());
-            match self.interpreter.interpret(ast) {
-                Ok(v) => println!("{}", v),
-                Err(err) => {
-                    self.runtime_error(err);
-                }
-            }
+        for stmt in &ast {
+            println!("{}", stmt.print());
+        }
+        if let Err(err) = self.interpreter.interpret(ast) {
+            self.runtime_error(err);
         }
 
         // type infer the parse

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use std::fs;
 use std::io::{self, Write};
 
 mod ast;
+mod environment;
 mod interpreter;
 mod parser;
 mod scanner;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -77,7 +77,9 @@ impl<'code> Parser<'code> {
         }
 
         if self.match_next(&[TokenType::LeftBrace]).is_some() {
-            return Ok(Stmt::Block { statements: self.block()? });
+            return Ok(Stmt::Block {
+                statements: self.block()?,
+            });
         }
 
         self.expression_statement()
@@ -246,13 +248,13 @@ impl<'code> Parser<'code> {
         Ok(Stmt::Expression { expression })
     }
 
-    fn block(&mut self) -> Result<Vec<Box<Stmt>>, ParseError> {
-        let statements = Vec::new();
+    fn block(&mut self) -> Result<Vec<Stmt>, ParseError> {
+        let mut statements = Vec::new();
 
         while !self.check(&TokenType::RightBrace) {
             match self.declaration()? {
                 None => break,
-                Some(s) => statements.push(Box::new(s))
+                Some(s) => statements.push(s),
             }
         }
 

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -5,7 +5,7 @@ use crate::Reportable;
 
 pub struct Scanner<'code> {
     source: &'code String,
-    tokens: Vec<Token<'code>>,
+    tokens: Vec<Token>,
     start: usize,
     current: usize,
     line: usize,
@@ -55,7 +55,7 @@ const KEYWORDS: &[(&str, TokenType)] = &[
 fn get_keyword(key: &str) -> Result<TokenType, usize> {
     KEYWORDS
         .binary_search_by(|(k, _)| k.cmp(&key))
-        .map(|x| KEYWORDS[x].1)
+        .map(|x| KEYWORDS[x].1.clone())
 }
 
 fn is_digit(c: &str) -> bool {
@@ -91,11 +91,7 @@ impl<'code> Scanner<'code> {
             }
         }
 
-        self.tokens.push(Token {
-            t: TokenType::Eof,
-            lexeme: "",
-            line: self.line,
-        });
+        self.tokens.push(Token::new(TokenType::Eof, "", self.line));
 
         (&self.tokens, errs)
     }
@@ -277,7 +273,8 @@ impl<'code> Scanner<'code> {
 
         self.advance();
         self.add_token(TokenType::String(
-            &self.source[self.next_char(self.start)..self.offset_char(self.current, -1)],
+            (&self.source[self.next_char(self.start)..self.offset_char(self.current, -1)])
+                .to_string(),
         ));
 
         Ok(Some(()))
@@ -314,13 +311,9 @@ impl<'code> Scanner<'code> {
         };
     }
 
-    fn add_token(&mut self, t: TokenType<'code>) {
+    fn add_token(&mut self, t: TokenType) {
         let lexeme = &self.source[self.start..self.current];
-        self.tokens.push(Token {
-            t,
-            lexeme,
-            line: self.line,
-        })
+        self.tokens.push(Token::new(t, lexeme, self.line))
     }
 
     fn error(&self, msg: impl AsRef<str>) -> ScanError {

--- a/src/token.rs
+++ b/src/token.rs
@@ -2,8 +2,8 @@ use std::fmt;
 
 use crate::PrettyPrinting;
 
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub enum TokenType<'literal> {
+#[derive(Clone, Debug, PartialEq)]
+pub enum TokenType {
     // Single-character tokens
     LeftParen,
     RightParen,
@@ -29,7 +29,7 @@ pub enum TokenType<'literal> {
 
     // Literals
     Identifier,
-    String(&'literal str),
+    String(String),
     Number(f64),
 
     // Keywords
@@ -54,7 +54,7 @@ pub enum TokenType<'literal> {
     Eof,
 }
 
-impl fmt::Display for TokenType<'_> {
+impl fmt::Display for TokenType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             TokenType::Number(v) => write!(f, "Number {}", v),
@@ -64,20 +64,30 @@ impl fmt::Display for TokenType<'_> {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub struct Token<'code> {
-    pub t: TokenType<'code>,
-    pub lexeme: &'code str,
+#[derive(Clone, Debug, PartialEq)]
+pub struct Token {
+    pub t: TokenType,
+    pub lexeme: String,
     pub line: usize,
 }
 
-impl fmt::Display for Token<'_> {
+impl Token {
+    pub fn new(t: TokenType, lexeme: impl AsRef<str>, line: usize) -> Self {
+        Token {
+            t,
+            lexeme: lexeme.as_ref().to_string(),
+            line,
+        }
+    }
+}
+
+impl fmt::Display for Token {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "[{}] {} {}", self.line, self.t, self.lexeme)
     }
 }
 
-impl PrettyPrinting for Token<'_> {
+impl PrettyPrinting for Token {
     fn print(&self) -> String {
         match self.t {
             TokenType::Number(v) => format!("{}", v),


### PR DESCRIPTION
* Add print statements, expression statements, variable assignment, and block scope
* semicolon is now required at the end of each statement (no more lone expressions)
* implement lexical scope with `Rc<RefCell<Environment>>` - the `Rc` and `RefCell` are needed due to the tree pattern of nesting environments as well as the mutation of the environment (a hashmap wrapper)
* clone tokens more to make lifetime management easier (still using lifetimes for big chunks of data like the source code, just not at the smallest level of tokens and token types)
* clean up the output with headers and colors (keeping intermediate state printing for debugging)