### PR TITLE
Feat functions, callables, return

### DIFF
--- a/lox-programs/counter.lox
+++ b/lox-programs/counter.lox
@@ -1,0 +1,13 @@
+fun makeCounter() {
+  var i = 0;
+  fun count() {
+    i = i + 1;
+    print i;
+  }
+
+  return count;
+}
+
+var counter = makeCounter();
+counter(); // "1".
+counter(); // "2".

--- a/lox-programs/fib-rec.lox
+++ b/lox-programs/fib-rec.lox
@@ -1,0 +1,8 @@
+fun fib(n) {
+  if (n <= 1) return n;
+  return fib(n - 2) + fib(n - 1);
+}
+
+for (var i = 0; i < 20; i = i + 1) {
+  print fib(i);
+}

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -12,6 +12,11 @@ pub enum Expr {
         op: Token,
         right: Box<Expr>,
     },
+    Call {
+        callee: Box<Expr>,
+        paren: Token,
+        arguments: Vec<Expr>,
+    },
     Grouping {
         expression: Box<Expr>,
     },
@@ -39,6 +44,16 @@ impl PrettyPrinting for Expr {
             Expr::Binary { left, right, op } => {
                 format!("({} {} {})", op.print(), left.print(), right.print())
             }
+            Expr::Call {
+                callee, arguments, ..
+            } => {
+                let mut s = format!("({}", callee.print());
+                for argument in arguments {
+                    s += " ";
+                    s += &argument.print();
+                }
+                s + ")"
+            }
             Expr::Unary { right, op } => format!("({} {})", op.print(), right.print()),
             Expr::Grouping { expression } => format!("(group {})", expression.print()),
             Expr::Literal { value } => value.print(),
@@ -57,6 +72,11 @@ pub enum Stmt {
     },
     Expression {
         expression: Expr,
+    },
+    Function {
+        name: Token,
+        parameters: Vec<Token>,
+        body: Vec<Stmt>,
     },
     If {
         condition: Expr,
@@ -88,6 +108,23 @@ impl PrettyPrinting for Stmt {
                 s + ")"
             }
             Stmt::Expression { expression } => format!("(; {})", expression.print()),
+            Stmt::Function {
+                name,
+                parameters,
+                body,
+            } => {
+                let mut s = format!("({}", name);
+                for parameter in parameters {
+                    s += " ";
+                    s += &parameter.print();
+                }
+                s += "(body";
+                for statement in body {
+                    s += " ";
+                    s += &statement.print();
+                }
+                s + "))"
+            }
             Stmt::If {
                 condition,
                 then_branch,

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -86,6 +86,10 @@ pub enum Stmt {
     Print {
         expression: Expr,
     },
+    Return {
+        keyword: Token,
+        value: Option<Expr>,
+    },
     Var {
         name: Token,
         initializer: Option<Expr>,
@@ -142,9 +146,11 @@ impl PrettyPrinting for Stmt {
 
                 s + ")"
             }
-            Stmt::Print { expression } => {
-                format!("(print {})", expression.print())
-            }
+            Stmt::Print { expression } => format!("(print {})", expression.print()),
+            Stmt::Return { value, .. } => match value {
+                Some(expression) => format!("(return {})", expression.print()),
+                None => "(return)".to_string(),
+            },
             Stmt::Var { name, initializer } => match initializer {
                 Some(v) => format!("(var {} {})", name.print(), v.print()),
                 None => format!("(var {})", name.print()),

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -47,12 +47,7 @@ impl PrettyPrinting for Expr {
             Expr::Call {
                 callee, arguments, ..
             } => {
-                let mut s = format!("({}", callee.print());
-                for argument in arguments {
-                    s += " ";
-                    s += &argument.print();
-                }
-                s + ")"
+                format!("({} {})", callee.print(), arguments.print())
             }
             Expr::Unary { right, op } => format!("({} {})", op.print(), right.print()),
             Expr::Grouping { expression } => format!("(group {})", expression.print()),
@@ -104,12 +99,7 @@ impl PrettyPrinting for Stmt {
     fn print(&self) -> String {
         match self {
             Stmt::Block { statements } => {
-                let mut s = "(block".to_string();
-                for statement in statements {
-                    s += " ";
-                    s += &statement.print();
-                }
-                s + ")"
+                format!("(block {})", statements.print())
             }
             Stmt::Expression { expression } => format!("(; {})", expression.print()),
             Stmt::Function {
@@ -117,17 +107,12 @@ impl PrettyPrinting for Stmt {
                 parameters,
                 body,
             } => {
-                let mut s = format!("({}", name);
-                for parameter in parameters {
-                    s += " ";
-                    s += &parameter.print();
-                }
-                s += "(body";
-                for statement in body {
-                    s += " ";
-                    s += &statement.print();
-                }
-                s + "))"
+                format!(
+                    "({} {} (body {}))",
+                    name.print(),
+                    parameters.print(),
+                    body.print()
+                )
             }
             Stmt::If {
                 condition,

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -2,13 +2,13 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 
-use crate::interpreter::LoxValue;
 use crate::token::Token;
+use crate::types::LoxValue;
 
 #[derive(Debug)]
 pub struct Environment {
     values: HashMap<String, LoxValue>,
-    pub enclosing: Option<Rc<RefCell<Environment>>>,
+    enclosing: Option<Rc<RefCell<Environment>>>,
 }
 
 impl Environment {
@@ -21,6 +21,10 @@ impl Environment {
 
     pub fn define(&mut self, name: &Token, value: LoxValue) {
         self.values.insert(name.lexeme.clone(), value);
+    }
+
+    pub fn define_name(&mut self, name: impl AsRef<str>, value: LoxValue) {
+        self.values.insert(name.as_ref().to_string(), value);
     }
 
     pub fn get(&self, name: &Token) -> Option<LoxValue> {

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -64,7 +64,7 @@ impl Reportable for InterpreterError {
 #[derive(Debug)]
 pub struct Interpreter {
     environment: Rc<RefCell<Environment>>,
-    pub globals: Rc<RefCell<Environment>>,
+    globals: Rc<RefCell<Environment>>,
 }
 
 impl Interpreter {
@@ -116,8 +116,12 @@ impl Interpreter {
                 parameters,
                 body,
             } => {
-                let function =
-                    LoxValue::Function(UserFunction::new(name.clone(), parameters, body));
+                let function = LoxValue::Function(UserFunction::new(
+                    name.clone(),
+                    parameters,
+                    body,
+                    Rc::clone(&environment),
+                ));
                 environment.borrow_mut().define(&name, function);
             }
             Stmt::If {

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -16,14 +16,6 @@ fn is_truthy(val: &LoxValue) -> bool {
     }
 }
 
-// make this an enum with exception and return variants
-// pub struct InterpreterError {
-//     line: usize,
-//     location: String,
-//     message: String,
-//     pub return_value: Option<LoxValue>,
-// }
-
 pub enum InterpreterError {
     Exception {
         line: usize,

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod interpreter;
 mod parser;
 mod scanner;
 mod token;
+mod types;
 
 pub trait PrettyPrinting {
     fn print(&self) -> String;

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,18 @@ pub trait PrettyPrinting {
     fn print(&self) -> String;
 }
 
+impl<T> PrettyPrinting for Vec<T>
+where
+    T: PrettyPrinting,
+{
+    fn print(&self) -> String {
+        self.iter()
+            .map(PrettyPrinting::print)
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+}
+
 pub trait Reportable {
     fn report(&self);
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -96,7 +96,7 @@ impl<'code> Parser<'code> {
         }
 
         if let Some(t) = self.match_next(&[TokenType::Return]) {
-            return self.return_statement(t.clone());
+            return self.return_statement(t);
         }
 
         if self.match_next(&[TokenType::While]).is_some() {
@@ -240,12 +240,8 @@ impl<'code> Parser<'code> {
     fn call(&mut self) -> Result<Expr, ParseError> {
         let mut expr = self.primary()?;
 
-        loop {
-            if let Some(t) = self.match_next(&[TokenType::LeftParen]) {
-                expr = self.finish_call(expr, t)?;
-            } else {
-                break;
-            }
+        while let Some(t) = self.match_next(&[TokenType::LeftParen]) {
+            expr = self.finish_call(expr, t)?;
         }
 
         Ok(expr)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -77,12 +77,12 @@ impl<'code> Parser<'code> {
     }
 
     fn statement(&mut self) -> Result<Stmt, ParseError> {
-        if self.match_next(&[TokenType::Print]).is_some() {
-            return self.print_statement();
+        if self.match_next(&[TokenType::For]).is_some() {
+            return self.for_statement();
         }
 
-        if self.match_next(&[TokenType::While]).is_some() {
-            return self.while_statement();
+        if self.match_next(&[TokenType::If]).is_some() {
+            return self.if_statement();
         }
 
         if self.match_next(&[TokenType::LeftBrace]).is_some() {
@@ -91,12 +91,16 @@ impl<'code> Parser<'code> {
             });
         }
 
-        if self.match_next(&[TokenType::For]).is_some() {
-            return self.for_statement();
+        if self.match_next(&[TokenType::Print]).is_some() {
+            return self.print_statement();
         }
 
-        if self.match_next(&[TokenType::If]).is_some() {
-            return self.if_statement();
+        if let Some(t) = self.match_next(&[TokenType::Return]) {
+            return self.return_statement(t.clone());
+        }
+
+        if self.match_next(&[TokenType::While]).is_some() {
+            return self.while_statement();
         }
 
         self.expression_statement()
@@ -322,6 +326,17 @@ impl<'code> Parser<'code> {
             parameters,
             body,
         })
+    }
+
+    fn return_statement(&mut self, keyword: Token) -> Result<Stmt, ParseError> {
+        let mut value = None;
+        if !self.check(&TokenType::Semicolon) {
+            value = Some(self.expression()?);
+        }
+
+        self.consume(TokenType::Semicolon, "expect ';' after return statement")?;
+
+        Ok(Stmt::Return { keyword, value })
     }
 
     fn var_declaration(&mut self) -> Result<Stmt, ParseError> {

--- a/src/types.rs
+++ b/src/types.rs
@@ -170,14 +170,21 @@ pub struct UserFunction {
     name: Token,
     parameters: Vec<Token>,
     body: Vec<Stmt>,
+    closure: Rc<RefCell<Environment>>,
 }
 
 impl UserFunction {
-    pub fn new(name: Token, parameters: Vec<Token>, body: Vec<Stmt>) -> Self {
+    pub fn new(
+        name: Token,
+        parameters: Vec<Token>,
+        body: Vec<Stmt>,
+        closure: Rc<RefCell<Environment>>,
+    ) -> Self {
         Self {
             name,
             parameters,
             body,
+            closure: Rc::clone(&closure),
         }
     }
 }
@@ -200,7 +207,7 @@ impl Callable for UserFunction {
         self.check_arity(arguments, line)?;
 
         let environment = Rc::new(RefCell::new(Environment::new(Some(Rc::clone(
-            &interpreter.globals,
+            &self.closure,
         )))));
 
         // arity has already been checked, so unwrapping is safe

--- a/src/types.rs
+++ b/src/types.rs
@@ -211,8 +211,15 @@ impl Callable for UserFunction {
             );
         }
 
-        interpreter.execute_block(&self.body, Rc::clone(&environment))?;
-
-        Ok(LoxValue::Nil)
+        match interpreter.execute_block(&self.body, Rc::clone(&environment)) {
+            Ok(()) => Ok(LoxValue::Nil),
+            Err(e) => match e {
+                InterpreterError {
+                    return_value: Some(v),
+                    ..
+                } => Ok(v),
+                _ => Err(e),
+            },
+        }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,0 +1,218 @@
+use std::cell::RefCell;
+use std::fmt;
+use std::rc::Rc;
+
+use crate::ast::Stmt;
+use crate::environment::Environment;
+use crate::interpreter::{Interpreter, InterpreterError};
+use crate::token::{Token, TokenType};
+
+pub trait Callable {
+    fn arity(&self) -> usize;
+    fn location(&self) -> String;
+    fn check_arity(&self, arguments: &Vec<LoxValue>, line: usize) -> Result<(), InterpreterError> {
+        if self.arity() == arguments.len() {
+            Ok(())
+        } else {
+            Err(InterpreterError::new(
+                line,
+                self.location(),
+                "arity mismatch",
+            ))
+        }
+    }
+    fn call(
+        &self,
+        interpreter: &Interpreter,
+        arguments: &Vec<LoxValue>,
+        line: usize,
+    ) -> Result<LoxValue, InterpreterError>;
+}
+
+// ========== LOX VALUE ===========
+
+#[derive(Debug, Clone)]
+pub enum LoxValue {
+    Boolean(bool),
+    Nil,
+    Number(f64),
+    String(String),
+    Function(UserFunction),
+    Builtin(NativeFunction),
+}
+
+impl Callable for LoxValue {
+    fn arity(&self) -> usize {
+        match self {
+            LoxValue::Function(f) => f.arity(),
+            LoxValue::Builtin(f) => f.arity(),
+            _ => 0,
+        }
+    }
+
+    fn location(&self) -> String {
+        match self {
+            LoxValue::Function(f) => f.location(),
+            LoxValue::Builtin(f) => f.location(),
+            _ => "".to_string(),
+        }
+    }
+
+    fn call(
+        &self,
+        interpreter: &Interpreter,
+        arguments: &Vec<LoxValue>,
+        line: usize,
+    ) -> Result<LoxValue, InterpreterError> {
+        match self {
+            LoxValue::Function(callable) => callable.call(interpreter, arguments, line),
+            LoxValue::Builtin(callable) => callable.call(interpreter, arguments, line),
+            _ => Err(InterpreterError::new(
+                line,
+                format!("{}", self),
+                "can only call functions and classes",
+            )),
+        }
+    }
+}
+
+impl PartialEq for LoxValue {
+    fn eq(&self, other: &Self) -> bool {
+        println!("{} {}", self, other);
+        match (self, other) {
+            (LoxValue::Nil, LoxValue::Nil) => false,
+            (LoxValue::Boolean(a), LoxValue::Boolean(b)) => a == b,
+            (LoxValue::Number(a), LoxValue::Number(b)) => a == b,
+            (LoxValue::String(a), LoxValue::String(b)) => a == b,
+            (_, _) => false,
+        }
+    }
+}
+impl Eq for LoxValue {}
+
+impl TryFrom<&Token> for LoxValue {
+    type Error = InterpreterError;
+
+    fn try_from(value: &Token) -> Result<Self, Self::Error> {
+        match &value.t {
+            TokenType::Nil => Ok(Self::Nil),
+            TokenType::True => Ok(Self::Boolean(true)),
+            TokenType::False => Ok(Self::Boolean(false)),
+            TokenType::Number(v) => Ok(Self::Number(*v)),
+            TokenType::String(v) => Ok(Self::String(v.to_string())),
+            _ => Err(InterpreterError::from_token(value, "Unexpected value")),
+        }
+    }
+}
+
+impl fmt::Display for LoxValue {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            LoxValue::Number(v) => write!(f, "{}", v),
+            LoxValue::String(v) => write!(f, "{}", v),
+            LoxValue::Boolean(v) => write!(f, "{}", v),
+            LoxValue::Nil => write!(f, "nil"),
+            LoxValue::Builtin(_) => write!(f, "<native fun>"),
+            LoxValue::Function(fun) => write!(f, "<fun {}>", fun.location()),
+        }
+    }
+}
+
+// ========== NATIVE FUNCTION ===========
+
+type FnPtr = fn(&Vec<LoxValue>) -> Result<LoxValue, String>;
+
+#[derive(Clone)]
+pub struct NativeFunction {
+    arity: usize,
+    body: FnPtr,
+}
+
+impl NativeFunction {
+    pub fn new(body: FnPtr, arity: usize) -> Self {
+        Self { arity, body }
+    }
+}
+
+impl fmt::Debug for NativeFunction {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.location())
+    }
+}
+
+impl Callable for NativeFunction {
+    fn arity(&self) -> usize {
+        self.arity
+    }
+
+    fn location(&self) -> String {
+        "<native fn>".to_string()
+    }
+
+    fn call(
+        &self,
+        _interpreter: &Interpreter,
+        arguments: &Vec<LoxValue>,
+        line: usize,
+    ) -> Result<LoxValue, InterpreterError> {
+        self.check_arity(arguments, line)?;
+        match (self.body)(arguments) {
+            Ok(v) => Ok(v),
+            Err(s) => Err(InterpreterError::new(line, self.location(), s)),
+        }
+    }
+}
+
+// ========== USER FUNCTION ===========
+
+#[derive(Clone, Debug)]
+pub struct UserFunction {
+    name: Token,
+    parameters: Vec<Token>,
+    body: Vec<Stmt>,
+}
+
+impl UserFunction {
+    pub fn new(name: Token, parameters: Vec<Token>, body: Vec<Stmt>) -> Self {
+        Self {
+            name,
+            parameters,
+            body,
+        }
+    }
+}
+
+impl Callable for UserFunction {
+    fn arity(&self) -> usize {
+        self.parameters.len()
+    }
+
+    fn location(&self) -> String {
+        format!("<fn {}>", self.name.lexeme)
+    }
+
+    fn call(
+        &self,
+        interpreter: &Interpreter,
+        arguments: &Vec<LoxValue>,
+        line: usize,
+    ) -> Result<LoxValue, InterpreterError> {
+        self.check_arity(arguments, line)?;
+
+        let environment = Rc::new(RefCell::new(Environment::new(Some(Rc::clone(
+            &interpreter.globals,
+        )))));
+
+        // arity has already been checked, so unwrapping is safe
+        for i in 0..self.arity() {
+            environment.borrow_mut().define(
+                self.parameters.get(i).unwrap(),
+                arguments.get(i).unwrap().clone(),
+            );
+        }
+
+        interpreter.execute_block(&self.body, Rc::clone(&environment))?;
+
+        Ok(LoxValue::Nil)
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -38,7 +38,6 @@ pub enum LoxValue {
     Number(f64),
     String(String),
     Function(Rc<Box<dyn Callable>>),
-    // Function(NativeFunction),
 }
 
 impl Callable for LoxValue {
@@ -66,7 +65,7 @@ impl Callable for LoxValue {
             LoxValue::Function(callable) => callable.call(interpreter, arguments, line),
             _ => Err(InterpreterError::new(
                 line,
-                format!("{}", self),
+                self.location(),
                 "can only call functions and classes",
             )),
         }


### PR DESCRIPTION
### Implement functions as per [chapter 10 of Crafting Interpreters](https://craftinginterpreters.com/functions.html) with lots of translation to rust
* move `LoxValue` and related `impls` to `types.rs`
* add the `Function(UserFunction)` and `Builtin(NativeFunction)` `LoxValue` enum variants
* add the `Callable` trait and implement it for `LoxValue` (delegates to callable variants or errors), `UserFunction`, and `NativeFunction`
  * `Callable` adds the `call` method as well as some helpers for checking arity matches and reporting errors
* add the `UserFunction` struct, which takes a function declaration and a closure and allows it to be checked for validity and called
* add the `NativeFunction` struct, which takes an arity (for checkability) and a closure (lambda) an allows it to be called
* add AST nodes, parsing ,and interpreting for function declarations, function calls, and return statements
* add globals dictionary (though it's actually currently unused and I think it'll be revealed why it's needed in a future chapter I hope... or I'll delete it at the end)