### PR TITLE
Refactor/simplify `Token` and `String` usage

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -184,31 +184,15 @@ mod tests {
     fn test_pretty_print() {
         let expression = Expr::Binary {
             left: Box::new(Expr::Unary {
-                op: Token {
-                    t: TokenType::Minus,
-                    lexeme: "-",
-                    line: 1,
-                },
+                op: Token::new(TokenType::Minus, "-", 1, 0),
                 right: Box::new(Expr::Literal {
-                    value: Token {
-                        t: TokenType::Number(123.0),
-                        lexeme: "45.67",
-                        line: 1,
-                    },
+                    value: Token::new(TokenType::Number(123.0), "123", 1, 1),
                 }),
             }),
-            op: Token {
-                t: TokenType::Star,
-                lexeme: "*",
-                line: 1,
-            },
+            op: Token::new(TokenType::Star, "*", 1, 5),
             right: Box::new(Expr::Grouping {
                 expression: Box::new(Expr::Literal {
-                    value: Token {
-                        t: TokenType::Number(45.67),
-                        lexeme: "45.67",
-                        line: 1,
-                    },
+                    value: Token::new(TokenType::Number(45.67), "45.67", 1, 7),
                 }),
             }),
         };

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -2,7 +2,6 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 
-use crate::token::Token;
 use crate::types::LoxValue;
 
 #[derive(Debug)]
@@ -19,55 +18,37 @@ impl Environment {
         }
     }
 
-    pub fn define(&mut self, name: &Token, value: LoxValue) {
-        self.values.insert(name.lexeme.clone(), value);
-    }
-
-    pub fn define_name(&mut self, name: impl AsRef<str>, value: LoxValue) {
+    pub fn define(&mut self, name: impl AsRef<str>, value: LoxValue) {
         self.values.insert(name.as_ref().to_string(), value);
     }
 
-    pub fn get(&self, name: &Token) -> Option<LoxValue> {
-        match self.values.get(&name.lexeme) {
-            Some(v) => Some(v.clone()),
-            None => match &self.enclosing {
-                Some(e) => e.borrow().get(name),
-                None => None,
-            },
-        }
+    pub fn get(&self, name: impl AsRef<str>) -> Option<LoxValue> {
+        self.get_at(0, name)
     }
 
-    pub fn get_at(&self, distance: usize, name: &Token) -> Option<LoxValue> {
-        self.get_at_name(distance, &name.lexeme)
-    }
-
-    pub fn get_at_name(&self, distance: usize, name: &String) -> Option<LoxValue> {
+    pub fn get_at(&self, distance: usize, name: impl AsRef<str>) -> Option<LoxValue> {
         if distance == 0 {
-            return self.values.get(name).cloned();
+            return self.values.get(name.as_ref()).cloned();
         }
 
         match &self.enclosing {
-            Some(e) => e.borrow().get_at_name(distance - 1, name),
+            Some(e) => e.borrow().get_at(distance - 1, name),
             None => None,
         }
     }
 
-    pub fn assign(&mut self, name: &Token, value: LoxValue) -> Option<()> {
-        if self.values.contains_key(&name.lexeme) {
-            self.values.insert(name.lexeme.clone(), value);
-            return Some(());
-        }
-
-        if let Some(e) = &self.enclosing {
-            return e.borrow_mut().assign(name, value);
-        }
-
-        None
+    pub fn assign(&mut self, name: impl AsRef<str>, value: LoxValue) -> Option<()> {
+        self.assign_at(0, name, value)
     }
 
-    pub fn assign_at(&mut self, distance: usize, name: &Token, value: LoxValue) -> Option<()> {
+    pub fn assign_at(
+        &mut self,
+        distance: usize,
+        name: impl AsRef<str>,
+        value: LoxValue,
+    ) -> Option<()> {
         if distance == 0 {
-            self.values.insert(name.lexeme.clone(), value);
+            self.values.insert(name.as_ref().to_string(), value);
             return Some(());
         }
 

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -79,7 +79,7 @@ impl Interpreter {
         let globals = Rc::new(RefCell::new(Environment::new(None)));
 
         // move this if there are ever more native functions
-        globals.borrow_mut().define_name(
+        globals.borrow_mut().define(
             "clock",
             LoxValue::Builtin(NativeFunction::new(
                 |_arguments: &[LoxValue]| -> Result<LoxValue, String> {

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -303,9 +303,9 @@ impl Resolver {
         Ok(())
     }
 
-    fn define(&mut self, name: &Token) {
+    fn define(&mut self, name: impl AsRef<str>) {
         if let Some(scope) = self.stack.last_mut() {
-            scope.insert(name.lexeme.clone(), true);
+            scope.insert(name.as_ref().to_string(), true);
         }
     }
 }

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -274,7 +274,7 @@ impl<'code> Scanner<'code> {
 
         self.advance();
         self.add_token(TokenType::String(
-            (&self.source[self.next_char(self.start)..self.offset_char(self.current, -1)])
+            (self.source[self.next_char(self.start)..self.offset_char(self.current, -1)])
                 .to_string(),
         ));
 

--- a/src/token.rs
+++ b/src/token.rs
@@ -109,9 +109,12 @@ impl fmt::Display for Token {
 
 impl PrettyPrinting for Token {
     fn print(&self) -> String {
-        match self.t {
-            TokenType::Number(v) => format!("{}", v),
-            _ => self.lexeme.to_string(),
-        }
+        self.lexeme.clone()
+    }
+}
+
+impl AsRef<str> for Token {
+    fn as_ref(&self) -> &str {
+        self.lexeme.as_str()
     }
 }


### PR DESCRIPTION
* implement the `AsRef<str>` trait on `Token`
* this allowed the dependency on `Token` and dual methods to be dropped from `Environment`
* cleaned up other methods that really needed a string, but were being passed a token