### PR TITLE
Improve performance of lox-rs by avoiding clone operations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,7 @@ members = [
     "lox",
     "lox-wasm",
 ]
+
+[profile.release]
+debug = true
+opt-level = 3

--- a/lox-programs/fib-rec.lox
+++ b/lox-programs/fib-rec.lox
@@ -4,7 +4,7 @@ fun fib(n) {
   return fib(n - 2) + fib(n - 1);
 }
 
-for (var i = 0; i < 3; i = i + 1) {
+for (var i = 0; i < 28; i = i + 1) {
   print fib(i);
   print "returned";
 }

--- a/lox-programs/fib.lox
+++ b/lox-programs/fib.lox
@@ -1,8 +1,10 @@
 var a = 0;
 var temp;
 
-for (var b = 1; a < 10000; b = temp + b) {
-  print a;
-  temp = a;
-  a = b;
+for (var c = 1; c < 1000000; c = c + 1) {
+    for (var b = 1; a < 10000; b = temp + b) {
+      print a;
+      temp = a;
+      a = b;
+    }
 }

--- a/lox/src/environment.rs
+++ b/lox/src/environment.rs
@@ -6,7 +6,7 @@ use crate::types::LoxValue;
 
 #[derive(Debug)]
 pub struct Environment {
-    values: HashMap<String, LoxValue>,
+    values: HashMap<String, Rc<LoxValue>>,
     enclosing: Option<Rc<RefCell<Environment>>>,
 }
 
@@ -19,14 +19,15 @@ impl Environment {
     }
 
     pub fn define(&mut self, name: impl AsRef<str>, value: LoxValue) {
-        self.values.insert(name.as_ref().to_string(), value);
+        self.values
+            .insert(name.as_ref().to_string(), Rc::new(value));
     }
 
-    pub fn get(&self, name: impl AsRef<str>) -> Option<LoxValue> {
+    pub fn get(&self, name: impl AsRef<str>) -> Option<Rc<LoxValue>> {
         self.get_at(0, name)
     }
 
-    pub fn get_at(&self, distance: usize, name: impl AsRef<str>) -> Option<LoxValue> {
+    pub fn get_at(&self, distance: usize, name: impl AsRef<str>) -> Option<Rc<LoxValue>> {
         if distance == 0 {
             return self.values.get(name.as_ref()).cloned();
         }
@@ -48,7 +49,8 @@ impl Environment {
         value: LoxValue,
     ) -> Option<()> {
         if distance == 0 {
-            self.values.insert(name.as_ref().to_string(), value);
+            self.values
+                .insert(name.as_ref().to_string(), Rc::new(value));
             return Some(());
         }
 

--- a/lox/src/interpreter.rs
+++ b/lox/src/interpreter.rs
@@ -143,7 +143,7 @@ impl Interpreter {
                             }
                         };
 
-                        environment.borrow_mut().define(&name, LoxValue::Nil);
+                        environment.borrow_mut().define(name, LoxValue::Nil);
 
                         let env = Rc::new(RefCell::new(Environment::new(Some(Rc::clone(
                             &environment,
@@ -154,7 +154,7 @@ impl Interpreter {
 
                         (super_class_class, env)
                     } else {
-                        environment.borrow_mut().define(&name, LoxValue::Nil);
+                        environment.borrow_mut().define(name, LoxValue::Nil);
                         (None, Rc::clone(&environment))
                     };
 
@@ -190,7 +190,7 @@ impl Interpreter {
                     method_map,
                 ))));
 
-                environment.borrow_mut().assign(&name, class);
+                environment.borrow_mut().assign(name, class);
             }
             Stmt::Expression { expression } => {
                 self.evaluate(expression, Rc::clone(&environment), locals)?;
@@ -207,7 +207,7 @@ impl Interpreter {
                     Rc::clone(&environment),
                     false,
                 ));
-                environment.borrow_mut().define(&name, function);
+                environment.borrow_mut().define(name, function);
             }
             Stmt::If {
                 condition,
@@ -250,7 +250,7 @@ impl Interpreter {
                         .clone();
                 }
 
-                environment.borrow_mut().define(&name, value);
+                environment.borrow_mut().define(name, value);
             }
             Stmt::While { condition, body } => {
                 while is_truthy(
@@ -295,7 +295,7 @@ impl Interpreter {
                     Some(distance) => {
                         if environment
                             .borrow_mut()
-                            .assign_at(*distance, &name, v.as_ref().clone())
+                            .assign_at(*distance, name, v.as_ref().clone())
                             .is_none()
                         {
                             return Err(InterpreterError::from_token(name, "undefined variable"));
@@ -305,7 +305,7 @@ impl Interpreter {
                         if self
                             .globals
                             .borrow_mut()
-                            .assign(&name, v.as_ref().clone())
+                            .assign(name, v.as_ref().clone())
                             .is_none()
                         {
                             return Err(InterpreterError::from_token(name, "undefined variable"));
@@ -465,7 +465,7 @@ impl Interpreter {
                 LoxValue::Instance(i) => {
                     let value_val = self.evaluate(value, Rc::clone(&environment), locals)?;
                     let mut i = i.clone();
-                    i.set(&name, value_val.as_ref().clone());
+                    i.set(name, value_val.as_ref().clone());
                     Ok(value_val)
                 }
                 _ => Err(InterpreterError::from_token(
@@ -488,7 +488,7 @@ impl Interpreter {
                     LoxValue::Class(c) => c,
                     _ => panic!("super referred to non-class"),
                 };
-                let res = match super_class_class.borrow().find_method(&method) {
+                let res = match super_class_class.borrow().find_method(method) {
                     Some(m) => m.bind(instance.clone()),
                     None => Err(InterpreterError::from_token(
                         method,

--- a/lox/src/interpreter.rs
+++ b/lox/src/interpreter.rs
@@ -449,12 +449,7 @@ impl Interpreter {
                             return Ok(left_val);
                         }
                     }
-                    _ => {
-                        return Err(InterpreterError::from_token(
-                            op,
-                            "Unknown logical operator",
-                        ))
-                    }
+                    _ => return Err(InterpreterError::from_token(op, "Unknown logical operator")),
                 }
 
                 Ok(self.evaluate(right, Rc::clone(&environment), locals)?)
@@ -479,11 +474,8 @@ impl Interpreter {
                 )),
             },
             Expr::Super { keyword, method } => {
-                let super_class =
-                    self.lookup_variable(keyword, Rc::clone(&environment), locals)?;
-                let distance = locals
-                    .get(keyword)
-                    .expect("super always in a nested scope");
+                let super_class = self.lookup_variable(keyword, Rc::clone(&environment), locals)?;
+                let distance = locals.get(keyword).expect("super always in a nested scope");
                 let blah = environment
                     .borrow()
                     .get_at(distance - 1, "this")

--- a/lox/src/resolver.rs
+++ b/lox/src/resolver.rs
@@ -163,9 +163,9 @@ impl Resolver {
                 else_branch,
             } => {
                 self.resolve_expression(condition)?;
-                self.resolve_statement(&**then_branch)?;
+                self.resolve_statement(then_branch)?;
                 if let Some(e) = else_branch {
-                    self.resolve_statement(&**e)?;
+                    self.resolve_statement(e)?;
                 }
             }
             Stmt::Print { expression } => {
@@ -198,7 +198,7 @@ impl Resolver {
             }
             Stmt::While { condition, body } => {
                 self.resolve_expression(condition)?;
-                self.resolve_statement(&**body)?;
+                self.resolve_statement(body)?;
             }
         };
 
@@ -208,36 +208,36 @@ impl Resolver {
     fn resolve_expression(&mut self, expression: &Expr) -> Result<(), ResolveError> {
         match expression {
             Expr::Assign { name, value } => {
-                self.resolve_expression(&**value)?;
+                self.resolve_expression(value)?;
                 self.resolve_local(name);
             }
             Expr::Binary { left, right, .. } => {
-                self.resolve_expression(&**left)?;
-                self.resolve_expression(&**right)?;
+                self.resolve_expression(left)?;
+                self.resolve_expression(right)?;
             }
             Expr::Call {
                 callee, arguments, ..
             } => {
-                self.resolve_expression(&**callee)?;
+                self.resolve_expression(callee)?;
 
                 for argument in arguments {
                     self.resolve_expression(argument)?;
                 }
             }
             Expr::Get { object, .. } => {
-                self.resolve_expression(&**object)?;
+                self.resolve_expression(object)?;
             }
             Expr::Grouping { expression } => {
-                self.resolve_expression(&**expression)?;
+                self.resolve_expression(expression)?;
             }
             Expr::Literal { .. } => {}
             Expr::Logical { left, right, .. } => {
-                self.resolve_expression(&**left)?;
-                self.resolve_expression(&**right)?;
+                self.resolve_expression(left)?;
+                self.resolve_expression(right)?;
             }
             Expr::Set { object, value, .. } => {
-                self.resolve_expression(&**object)?;
-                self.resolve_expression(&**value)?;
+                self.resolve_expression(object)?;
+                self.resolve_expression(value)?;
             }
             Expr::Super { keyword, .. } => {
                 if self.current_class == ClassType::None {
@@ -263,7 +263,7 @@ impl Resolver {
                 self.resolve_local(keyword);
             }
             Expr::Unary { right, .. } => {
-                self.resolve_expression(&**right)?;
+                self.resolve_expression(right)?;
             }
             Expr::Variable { name } => {
                 if let Some(scope) = self.stack.last() {


### PR DESCRIPTION
This improves the performance significantly by avoiding as many clone operations as possible. This is largely done by making things into RCs or references wherever possible. There is still room for improvement to get rid of some of the clones here, but performance is improved greatly:
- fib-rec.lox took 4.5 seconds on my machine, now takes 2 seconds.
- fib.lox took 6.5 seconds on my machine, now takes 0.5 seconds.

I updated the programs as well to be more useful for benchmarking, but maybe those should be new copies so that the small test versions can still live on their own.